### PR TITLE
Reznor Bridge Fix

### DIFF
--- a/asm/boost/sprites.asm
+++ b/asm/boost/sprites.asm
@@ -360,7 +360,7 @@ ReznorFix_SNES:
 	LDA.W #$C05A              
 	BRA .Shared
 .RegularLevel
-	LDY.W #$38FC
+	LDY.W #$38F8
 	LDA.W #$C022     
 .Shared
 	ADC $00                   

--- a/asm/boost/sprites.asm
+++ b/asm/boost/sprites.asm
@@ -354,7 +354,15 @@ ReznorFix_SNES:
 	REP #$31
 	LDA.L $7F837B             
 	TAX                       
+	LDA $6D9A
+	BPL .RegularLevel
+	LDY.W #$38FC
 	LDA.W #$C05A              
+	BRA .Shared
+.RegularLevel
+	LDY.W #$38FC
+	LDA.W #$C022     
+.Shared
 	ADC $00                   
 	STA.L $7F837D,X           
 	ORA.W #$2000              
@@ -362,7 +370,7 @@ ReznorFix_SNES:
 	LDA.W #$0240              
 	STA.L $7F837F,X           
 	STA.L $7F8385,X           
-	LDA.W #$38FC              
+	TYA
 	STA.L $7F8381,X           
 	STA.L $7F8387,X           
 	LDA.W #$00FF              


### PR DESCRIPTION
I currently am creating a patch which fixes the bridge Reznors' battle. The only issue is that fixing it on an SA-1 ROM requires changes to be made within SA-1 Pack since it reimplements the bridge destruction routine due to using Stripe Images (i.e. S-CPU only code), hence the creation of this pull request.