### PR TITLE
Fixed missing address remap at $05C671

### DIFF
--- a/asm/remap/addr.asm
+++ b/asm/remap/addr.asm
@@ -13211,6 +13211,8 @@ org $05C5C7
 	dw $7464
 org $05C66C
 	dw $7464
+org $05C671
+	dw $7464
 ;============== REMAPPER FOR $1465
 ;============== REMAPPER FOR $1466
 org $00F6FC


### PR DESCRIPTION
Fixes a bug where the "Layer 2 falls" sprite (ED) doesn't shake the ground before making layer 2 fall due to a missing $1464 remap.